### PR TITLE
Path fix

### DIFF
--- a/lib/compile-svg.js
+++ b/lib/compile-svg.js
@@ -31,7 +31,7 @@ SVGCompiler.prototype.processFilesForTarget = function (files) {
   //Iterate over files and add them to spriter
   files.forEach(function (file) { 
 
-    var fullPath = process.env.PWD + '/' + file._resourceSlot.inputResource.path;
+    var fullPath = process.cwd() + '/' + file._resourceSlot.inputResource.path;
     var fileName = fullPath.replace(/^.*[\\\/]/, '');
     var data = fs.readFileSync(fullPath, {encoding: 'utf-8'});
 


### PR DESCRIPTION
@SachaG process.env.PWD is undefined in windows, using cwd() resolves correctly and I feel it's the best way to get the actual current directory. Perhaps give it a quick try on mac/linux? 

Cheers,
Nick
